### PR TITLE
Refine test selection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,15 +34,12 @@ jobs:
       - name: Setup LocalStack
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
-          TMP_USER: ${{ secrets.TMP_USER }}
-          TMP_PW: ${{ secrets.TMP_PW }}
         run: |
           source .venv/bin/activate
-          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
+          pip install --pre localstack
           docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
-          localstack login -u $TMP_USER -p $TMP_PW
-          localstack extensions init
-          localstack extensions dev enable ./collect-raw-metric-data-extension
+          LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack extensions init
+          LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack extensions dev enable ./collect-raw-metric-data-extension
       - name: Run Moto Integration Tests against LocalStack
         env:
            LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}

--- a/conftest.py
+++ b/conftest.py
@@ -201,7 +201,7 @@ def pytest_collection_modifyitems(items, config):
             excluded_service.append(tmp)
 
     # ec2 does not follow the naming conventions, all classes except the following should be run:
-    excluded_ec2_test_cases = [
+    excluded_ec2_tests = [
         "test_vm_export.py",
         "test_vm_import.py",
         "test_utils.py",
@@ -212,6 +212,9 @@ def pytest_collection_modifyitems(items, config):
         "helpers.py",
         "test_amazon_dev_pay.py",
     ]
+
+    # included tests, that do not match the pattern test_{service_name}
+    included_tests = ["test_policies.py"]
     # filter tests based on pattern - e.g. every test that includes test_{service_name}
     for item in items:
         for service in selected_services:
@@ -219,19 +222,20 @@ def pytest_collection_modifyitems(items, config):
                 continue
             test_class_name = item._nodeid.split("::")[0].split("/")[-1]
             test_package_name = item._nodeid.split("/")[1]
-            if any([True for x in excluded_service if x in test_class_name]):
+            if any([x in test_class_name for x in excluded_service]):
                 deselected_items.append(item)
-            elif any([True for x in excluded_test_cases if x in item._nodeid]):
+            elif any([x in item._nodeid for x in excluded_test_cases]):
                 deselected_items.append(item)
             elif (
                 f"test_{service}" in test_class_name
-                or "test_policies" in test_class_name
                 or f'test_{service.replace("-", "")}' in test_class_name
             ):
                 selected_items.append(item)
+            elif any([x in test_class_name for x in included_tests]):
+                selected_items.append(item)
             elif "test_ec2" == test_package_name:
                 # ec2 does not follow the conventions, some testclasses have only an empty test
-                if any([True for x in excluded_ec2_test_cases if x in item._nodeid]):
+                if any([x in item._nodeid for x in excluded_ec2_tests]):
                     deselected_items.append(item)
                 else:
                     selected_items.append(item)

--- a/conftest.py
+++ b/conftest.py
@@ -200,21 +200,41 @@ def pytest_collection_modifyitems(items, config):
         if tmp not in selected_services:
             excluded_service.append(tmp)
 
+    # ec2 does not follow the naming conventions, all classes except the following should be run:
+    excluded_ec2_test_cases = [
+        "test_vm_export.py",
+        "test_vm_import.py",
+        "test_utils.py",
+        "test_server.py",
+        "test_reserved_instances.py",
+        "test_monitoring.py",
+        "test_ip_addresses.py",
+        "helpers.py",
+        "test_amazon_dev_pay.py",
+    ]
     # filter tests based on pattern - e.g. every test that includes test_{service_name}
     for item in items:
         for service in selected_services:
             if item in deselected_items or item in selected_items:
                 continue
             test_class_name = item._nodeid.split("::")[0].split("/")[-1]
+            test_package_name = item._nodeid.split("/")[1]
             if any([True for x in excluded_service if x in test_class_name]):
                 deselected_items.append(item)
             elif any([True for x in excluded_test_cases if x in item._nodeid]):
                 deselected_items.append(item)
             elif (
                 f"test_{service}" in test_class_name
+                or "test_policies" in test_class_name
                 or f'test_{service.replace("-", "")}' in test_class_name
             ):
                 selected_items.append(item)
+            elif "test_ec2" == test_package_name:
+                # ec2 does not follow the conventions, some testclasses have only an empty test
+                if any([True for x in excluded_ec2_test_cases if x in item._nodeid]):
+                    deselected_items.append(item)
+                else:
+                    selected_items.append(item)
         if item not in selected_items:
             deselected_items.append(item)
 


### PR DESCRIPTION
Add ec2 tests which do not follow the general pattern of `test_{service_name}...py`. 
Also include `test_policies.py` explicitly, as it also hold tests that should run against LocalStack.