### PR TITLE
exclude lambda tests, add workflow-dispatch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,9 +5,19 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      selected-services:
+        type: string
+        required: false
+        default: 'all'
+        description: 'enter a list of services (comma separated), that will be used to filter for tests'
   push:
     branches:
       - main
+permissions:
+  contents: write
+
 jobs:
   run-moto-tests:
     runs-on: ubuntu-latest
@@ -48,7 +58,7 @@ jobs:
            LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           source .venv/bin/activate
-          python -m pytest --durations=10 --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
+          python -m pytest --durations=10 --services ${{ inputs.selected-services | 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
       - name: Archive Test Result
         if: always()
         uses: actions/upload-artifact@v3
@@ -66,3 +76,10 @@ jobs:
         with:
           junit_files: target/reports/*.xml
           check_name: Moto Integration Tests against LocalStack Results
+      - name: Prevent Workflows from getting Stale
+        if: always()
+        uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+             #this message should prevent automatic triggering of workflows
+             #see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+            commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
            LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           source .venv/bin/activate
-          python -m pytest --durations=10 --services ${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
+          python -m pytest --durations=10 --services=${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
       - name: Archive Test Result
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,7 +58,7 @@ jobs:
            LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
         run: |
           source .venv/bin/activate
-          python -m pytest --durations=10 --services ${{ inputs.selected-services | 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
+          python -m pytest --durations=10 --services ${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
       - name: Archive Test Result
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,11 @@ on:
   push:
     branches:
       - main
+
 permissions:
   contents: write
+  checks: write
+  pull-requests: write
 
 jobs:
   run-moto-tests:

--- a/conftest.py
+++ b/conftest.py
@@ -181,6 +181,8 @@ def pytest_collection_modifyitems(items, config):
 
     selected_items = []
     deselected_items = []
+    # TODO excluding EKS because it requires a lot of resources
+    excluded_service = ["eks"]
 
     if not selected_services:
         # no default, select all
@@ -191,17 +193,17 @@ def pytest_collection_modifyitems(items, config):
         selected_services = [k for k in json.loads(response).get("services").keys()]
         # included tests, that do not match the pattern test_{service_name}
         included_tests = ["test_policies.py"]
-        # exclude other services that run a long time, but are not yet implemented in localstack
-        tmp_excluded = ["acmpca", "emr-serverless", "lambda"]
+        # lambda started failing because of iam policies, will exclude for now
+        excluded_service.append("lambda")
     else:
         included_tests = []
         tmp_excluded = []
 
-    # TODO excluding EKS because it requires a lot of resources
-    excluded_service = ["eks"]
-
     # exclude "specific test, because it creates 51 databases
     excluded_test_cases = ["test_rds.py::test_get_databases_paginated"]
+
+    # exclude other services that run a long time, but are not yet implemented in localstack
+    tmp_excluded = ["acmpca", "emr-serverless"]
 
     for tmp in tmp_excluded:
         if tmp not in selected_services:

--- a/conftest.py
+++ b/conftest.py
@@ -174,7 +174,9 @@ def pytest_collection_modifyitems(items, config):
     With the option "--service=acm,lambda" a subset of services can be selected
     """
     selected_services = (
-        config.option.services.split(",") if config.option.services else None
+        config.option.services.split(",")
+        if config.option.services and config.option.services != "all"
+        else None
     )
 
     selected_items = []
@@ -187,6 +189,13 @@ def pytest_collection_modifyitems(items, config):
             "http://localhost:4566/_localstack/health"
         ).content.decode("utf-8")
         selected_services = [k for k in json.loads(response).get("services").keys()]
+        # included tests, that do not match the pattern test_{service_name}
+        included_tests = ["test_policies.py"]
+        # exclude other services that run a long time, but are not yet implemented in localstack
+        tmp_excluded = ["acmpca", "emr-serverless", "lambda"]
+    else:
+        included_tests = []
+        tmp_excluded = []
 
     # TODO excluding EKS because it requires a lot of resources
     excluded_service = ["eks"]
@@ -194,8 +203,6 @@ def pytest_collection_modifyitems(items, config):
     # exclude "specific test, because it creates 51 databases
     excluded_test_cases = ["test_rds.py::test_get_databases_paginated"]
 
-    # exclude other services that run a long time, but are not yet implemented in localstack
-    tmp_excluded = ["acmpca", "emr-serverless"]
     for tmp in tmp_excluded:
         if tmp not in selected_services:
             excluded_service.append(tmp)
@@ -213,8 +220,6 @@ def pytest_collection_modifyitems(items, config):
         "test_amazon_dev_pay.py",
     ]
 
-    # included tests, that do not match the pattern test_{service_name}
-    included_tests = ["test_policies.py"]
     # filter tests based on pattern - e.g. every test that includes test_{service_name}
     for item in items:
         for service in selected_services:


### PR DESCRIPTION
Lambda tests started failing last week, the logs indicate an invalid configuration related to iam. 

Those lines pop up continuously:
```
2023-06-23 12:27:46 2023-06-23T10:27:46.053  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS iam.GetRole => 404 (NoSuchEntity)
2023-06-23 12:27:46 2023-06-23T10:27:46.071  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS iam.CreateRole => 400 (MalformedPolicyDocument)
```
This caused the entire test suite to be delayed, and eventually get cancelled after 6 hours. There might be iam related issues with the moto test suite, that did not pop up yet.

* Excluded the lambda tests from the test run therefore (more tests might turn out to fail consequently).
* Added workflow-dispatch for the workflow with service selection
* Also added stale-prevention action, as we have seen that the workflow went stale two weeks ago, which blocks the docs-generation in our other repo.