### PR TITLE
fix reset endpoint + config patch, update api key access

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,19 +46,16 @@ jobs:
           cd collect-raw-metric-data-extension && make install
       - name: Setup LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
-          TMP_USER: ${{ secrets.TMP_USER }}
-          TMP_PW: ${{ secrets.TMP_PW }}
+          LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
         run: |
           source .venv/bin/activate
           pip install --pre localstack
           docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
-          localstack login -u $TMP_USER -p $TMP_PW  # login is currently required
           localstack extensions init
           localstack extensions dev enable ./collect-raw-metric-data-extension
       - name: Run Moto Integration Tests against LocalStack
         env:
-           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+           LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
         run: |
           source .venv/bin/activate
           python -m pytest --durations=10 --services=${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line


### PR DESCRIPTION
The test from this week showed a lot of test failures, compared to the week before. 

12th November:

![image](https://github.com/localstack/localstack-moto-test-coverage/assets/5726672/cd9e26a8-0924-4e7f-9020-1357088a564e)

vs 5th November:

![image](https://github.com/localstack/localstack-moto-test-coverage/assets/5726672/a2c39f81-30ae-4147-a10e-002f93360451)

I discovered only some minor issues in the `conftest.py`:
* the reset endpoint changed in the meantime
* the config patch for max-retries wasn't working

Also updated the workflow file:
* updated the api-key to use the organizational one
* removed the `login` which is not required anymore

I am not sure if the reset of the endpoint leads to the better test results, or we had an issue with the `latest` LocalStack version on 12.11. when the scheduled workflow ran. 

Anyhow, the test results now look better:
**3 542 successful** (2 517 on 5.11.)
**2 112 failed** (3 129 on 5.11.)