### PR TITLE
initially start LocalStack from the workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install localstack
-          docker pull localstack/localstack-pro:3.0     # Make sure to pull the latest version of the image
+          docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
           localstack extensions init
           localstack extensions dev enable ./collect-raw-metric-data-extension
       - name: Run Moto Integration Tests against LocalStack

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,9 +51,9 @@ jobs:
           source .venv/bin/activate
           pip install localstack
           docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
-          # localstack extensions init
-          # localstack extensions dev enable ./collect-raw-metric-data-extension
-          DEBUG=1 DISABLE_EVENTS=1 localstack start -d
+          localstack extensions init
+          localstack extensions dev enable ./collect-raw-metric-data-extension
+          DEBUG=1 DISABLE_EVENTS=1 DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 localstack start -d
           echo "Waiting for LocalStack startup..."
           localstack wait -t 30
           echo "Startup complete"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,8 +51,8 @@ jobs:
           source .venv/bin/activate
           pip install localstack
           docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
-          localstack extensions init
-          localstack extensions dev enable ./collect-raw-metric-data-extension
+          # localstack extensions init
+          # localstack extensions dev enable ./collect-raw-metric-data-extension
       - name: Run Moto Integration Tests against LocalStack
         env:
            LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install localstack
-          docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
+          docker pull localstack/localstack-pro:3.0     # Make sure to pull the latest version of the image
           localstack extensions init
           localstack extensions dev enable ./collect-raw-metric-data-extension
       - name: Run Moto Integration Tests against LocalStack
@@ -65,11 +65,6 @@ jobs:
         with:
           name: test-metrics
           path: target/reports
-      - name: Logout LocalStack
-        if: always()
-        run: |
-          source .venv/bin/activate
-          localstack logout
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,6 +53,10 @@ jobs:
           docker pull localstack/localstack-pro     # Make sure to pull the latest version of the image
           # localstack extensions init
           # localstack extensions dev enable ./collect-raw-metric-data-extension
+          DEBUG=1 DISABLE_EVENTS=1 localstack start -d
+          echo "Waiting for LocalStack startup..."
+          localstack wait -t 30
+          echo "Startup complete"
       - name: Run Moto Integration Tests against LocalStack
         env:
            LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
@@ -71,6 +75,11 @@ jobs:
         with:
           junit_files: target/reports/*.xml
           check_name: Moto Integration Tests against LocalStack Results
+      - name: LocalStack Logs
+        if: always()
+        run:
+          source .venv/bin/activate
+          localstack logs
       - name: Prevent Workflows from getting Stale
         if: always()
         uses: gautamkrishnar/keepalive-workflow@v1

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ install-dependencies: venv
 
 install: venv install-dependencies init-precommit update-moto init-extension
 	$(VENV_RUN); $(PIP_CMD) install pytest requests
-	$(VENV_RUN); $(PIP_CMD) install pytest requests
 
 run-tests:
 	cp conftest.py moto/tests/

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
+            "DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
+            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
+            "DNS_ADDRESS=127.0.0.1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
+            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
+            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
+            "DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
         )
 
         _localstack_health_check()

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
+            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start"
         )
 
         _localstack_health_check()


### PR DESCRIPTION
For some very weird reason, that I could not pin down yet, the moto-integration tests started failing a few weeks ago. 

```
....
collected 8269 items / 1 error / 2677 deselected / 1 skipped / 5592 selected

==================================== ERRORS ====================================
________________ ERROR collecting tests/test_core/test_mypy.py _________________
E   ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:
E   urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPConnection object at 0x7f9e8c76c160>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:
E   botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "http://localhost:4566/"
```

It was not possible to connect to LocalStack anymore, e.g. the container didn't seem to start right. 

This how the logic currently works:
* A module-scoped fixture will start LocalStack using a simple `os.system` using `localstack start -d` 
* The module-scoped fixture shuts down LocalStack as well (previously we had some issues with memory hungry tests, e.g. `ec2` and others, that would not clean up resources properly).

Tried to do a lot of debugging here, but couldn't find the initial cause yet:
- the container is starting, but it never gets in the READY state for some reason
- it seems to be stuck after call `Executing command: whoami`

As a workaround, I tried to start LocalStack directly in the workflow, using the same ENVs - which worked without any issues.  Subsequently, starting and stopping LocalStack (initiated by the fixture) seems to work as well (but why?! 🤔🥲 ). 

I would like to merge this state now, as it seems something, but we should still try to identify the underlying issue here.
