### PR TITLE
upgrade imports and patches to moto v5

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ from requests.adapters import HTTPAdapter, Retry
 from tests import DEFAULT_ACCOUNT_ID
 
 from moto import settings
-from moto.core.models import BaseMockAWS
+from moto.core.models import MockAWS
 
 BASE_PATH = os.path.join(os.path.dirname(__file__), "../../target/reports")
 
@@ -47,13 +47,13 @@ def default_localstack_client_fixture() -> Iterator[None]:
     This is required, because some tests explicelty check the returned arn, and by default LocalStack will assume ID 00000000
     """
 
-    def localstack_mock_env_variables(self, org=BaseMockAWS.mock_env_variables):
+    def localstack_mock_env_variables(self, org=MockAWS._mock_env_variables):
         # patch the access key id to use the same one in LocalStack
-        self.FAKE_KEYS["AWS_ACCESS_KEY_ID"] = DEFAULT_ACCOUNT_ID
+        self._fake_creds["AWS_ACCESS_KEY_ID"] = DEFAULT_ACCOUNT_ID
         org(self)
 
     with patch(
-        "moto.core.models.BaseMockAWS.mock_env_variables",
+        "moto.core.models.MockAWS._mock_env_variables",
         autospec=True,
         side_effect=localstack_mock_env_variables,
     ):


### PR DESCRIPTION
## Motivation
[v5 of `moto` has just been released yesterday.](https://github.com/getmoto/moto/releases/tag/5.0.0) The last run of the pipeline failed yesterday due to wrong imports (v5 contains some internal refactorings). This PR updates the imports and patches to the latest commit in the repo.

## Changes
- Updates the imports and patches to the newly released (merged into `main`) changes of `getmoto/moto`