### PR TITLE
update artifacts GitHub actions to v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,7 +65,7 @@ jobs:
           python -m pytest --durations=10 --services=${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line
       - name: Archive Test Result
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-metrics
           path: target/reports


### PR DESCRIPTION
## Motivation
GitHub is currently phasing out support for `actions/upload-artifact` and `actions/download-artifact` versions other than the latest major release v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting December 5, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

This PR updates the the action to v4.

## Changes
Update the GitHub artifact action versions to v4 before the burn-down.