### PR TITLE
migrate from CI api key to CI auth token

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
           cd collect-raw-metric-data-extension && make install
       - name: Setup LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         run: |
           source .venv/bin/activate
           pip install localstack
@@ -59,7 +59,7 @@ jobs:
           echo "Startup complete"
       - name: Run Moto Integration Tests against LocalStack
         env:
-           LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
+           LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
         run: |
           source .venv/bin/activate
           python -m pytest --durations=10 --services=${{ inputs.selected-services || 'all' }} --timeout=300 --capture=no --junitxml=target/reports/pytest.xml moto/tests --tb=line

--- a/conftest.py
+++ b/conftest.py
@@ -119,7 +119,7 @@ def _startup_localstack():
         _localstack_health_check()
     except:
         os.system(
-            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY localstack start -d"
+            "DNS_ADDRESS=127.0.0.1 EXTENSION_DEV_MODE=1 DEBUG=1 DISABLE_EVENTS=1 LOCALSTACK_AUTH_TOKEN=$LOCALSTACK_AUTH_TOKEN localstack start -d"
         )
 
         _localstack_health_check()


### PR DESCRIPTION
## Motivation
With [LocalStack 4.0.0](https://github.com/localstack/localstack/releases/tag/v4.0.0), API keys have been fully migrated to auth tokens by also providing CI auth tokens.
This PR switches to using a new CI auth token instead of the old CI API key in the pipeline.

## Changes
- Use auth token instead of API keys.

/cc @SimonWallner @ackdav 