### PR TITLE
remove blocked GitHub action to re-enable workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -80,10 +80,3 @@ jobs:
         run:
           source .venv/bin/activate
           localstack logs
-      - name: Prevent Workflows from getting Stale
-        if: always()
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-             #this message should prevent automatic triggering of workflows
-             #see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-            commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"


### PR DESCRIPTION
https://github.com/localstack/localstack-moto-test-coverage/pull/6 added a step to our workflow which ensures that this workflow does not get stale. Unfortunately the used action ([gautamkrishnar/keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow)) has been blocked by GitHub, which prevents an execution of the main workflow of this repo alltogether.

This PR simply removes this step.
This means that about every 2 months without any kind of commits on the repo the workflow will be disabled again.
If this is the case, we need to push an (empty) commit and re-enable the workflow manually for now.